### PR TITLE
Fixes #7, Ansible playbook and roles for provisioning cloudforms

### DIFF
--- a/ansible/roles/miq_vm_provision/defaults/main.yml
+++ b/ansible/roles/miq_vm_provision/defaults/main.yml
@@ -1,0 +1,12 @@
+debug: false
+
+miq_provision_request_version: '1.1'
+
+miq_username:
+miq_password:
+miq_server:
+miq_email: "{{ miq_username }}@no-reply.net"
+
+miq_provision_options_json:
+miq_provision_tags_json:
+miq_ws_values_json:

--- a/ansible/roles/miq_vm_provision/tasks/main.yml
+++ b/ansible/roles/miq_vm_provision/tasks/main.yml
@@ -1,0 +1,94 @@
+#
+# PROVISION VM
+#
+- block:
+    - name: 'initialize the vm provision'
+      uri:
+        url:              'https://{{ miq_server }}/api/provision_requests'
+        user:             "{{ miq_username }}"
+        password:         "{{ miq_password }}"
+        method:           'POST'
+        force_basic_auth: true
+        status_code:      200,201
+        body_format:      'json'
+        validate_certs:   false
+        body:
+          action: 'create'
+          resource:
+            version: "{{ miq_provision_request_version }}"
+            template_fields:
+              name: "{{ miq_template_name | default(omit) }}"
+              id:   "{{ miq_template_id   | default(omit) }}"
+              guid: "{{ miq_template_guid | default(omit) }}"
+            vm_fields:         "{{ miq_provision_options_json | default('{}') }}"
+            tags:              "{{ miq_provision_tags_json    | default('{}') }}"
+            additional_values: "{{ miq_ws_values_json         | default('{}') }}"
+            requester:
+              auto_approve:     true
+              owner_email:      "{{ miq_email }}"
+              owner_first_name: "{{ miq_username }}"
+              owner_last_name:  "{{ miq_username }}"
+              username:         "{{ miq_username }}"
+      register: init_response
+
+  always:
+    - name: 'inspect init_response'
+      debug:
+        var: init_response
+      when: (debug | bool)
+
+#
+# WAIT FOR PROVISION TO COMPLETE
+#
+- block:
+    - name: 'wait for the provision to complete'
+      uri:
+        url:              'https://{{ miq_server }}/api/provision_requests/{{ init_response.json.results[0].id }}'
+        user:             "{{ miq_username }}"
+        password:         "{{ miq_password }}"
+        method:           'GET'
+        force_basic_auth: true
+        status_code:      200,201
+        body_format:      'json'
+        validate_certs:   false
+      register: provision_status
+      retries:  240
+      delay:    30
+      until:
+        - (provision_status.json.request_state | lower) == 'finished'
+      failed_when:
+        - (provision_status.json.status        | lower) == 'error'
+
+    - fail:
+        msg: 'provision failed'
+      when:
+        - (provision_status.json.request_state | lower) != 'finished'
+        - (provision_status.json.status        | lower) != 'ok'
+
+  always:
+    - name: 'inspect provision_status'
+      debug:
+        var: provision_status
+      when: (debug | bool)
+
+#
+# GET MIQ REQUEST TASK
+#
+- block:
+    - name: 'get the request task'
+      uri:
+        url:              'https://{{ miq_server }}/api/provision_requests/{{ init_response.json.results[0].id }}/request_tasks?expand=resources'
+        user:             "{{ miq_username }}"
+        password:         "{{ miq_password }}"
+        method:           'GET'
+        force_basic_auth: true
+        status_code:      200,201
+        body_format:      'json'
+        validate_certs:   false
+      register: request_task_status
+
+  always:
+    - name: 'inspect request_task_status'
+      debug:
+        var: request_task_status
+      when: (debug | bool)

--- a/ansible/roles/miq_vm_retire/defaults/main.yml
+++ b/ansible/roles/miq_vm_retire/defaults/main.yml
@@ -1,0 +1,6 @@
+debug: false
+
+miq_username:
+miq_password:
+miq_server:
+miq_vm_id:

--- a/ansible/roles/miq_vm_retire/tasks/main.yml
+++ b/ansible/roles/miq_vm_retire/tasks/main.yml
@@ -1,0 +1,67 @@
+#
+# INITIALIZE RETIREMENT
+#
+- block:
+    - name: 'initialize the vm retire'
+      uri:
+        url:              'https://{{ miq_server }}/api/vms/{{ miq_vm_id }}'
+        user:             "{{ miq_username }}"
+        password:         "{{ miq_password }}"
+        method:           'POST'
+        force_basic_auth: true
+        status_code:      200,201
+        body_format:      'json'
+        validate_certs:   false
+        body:
+          action: 'retire'
+      register: retire_response
+
+  always:
+    - name: 'inspect retire_response'
+      debug:
+        var: retire_response
+      when: (debug | bool)
+
+#
+# WAIT FOR RETIREMENT TO COMPLETE
+#
+# NOTE: we want to look for VMs which match the ID rather than go to the vms/ID endpoint because the retire check
+#       fails when the VM disappears (e.g. the retire process removes the VM from the VMDB)
+#
+- block:
+    - name: 'wait for the retirement to complete'
+      uri:
+        url:              'https://{{ miq_server }}/api/vms'
+        user:             "{{ miq_username }}"
+        password:         "{{ miq_password }}"
+        method:           'GET'
+        force_basic_auth: true
+        status_code:      200,201
+        body_format:      'json'
+        validate_certs:   false
+        body:
+          expand:     'resources'
+          attributes: 'id,name,retirement_state,retired,archived,orphaned'
+          filter:
+            - "id={{ miq_vm_id }}"
+      register: retire_status
+      retries:  240
+      delay:    30
+      until:
+        - ((retire_status.json.resources | length == 0)                             or
+          (retire_status.json.resources[0].retired | bool)                          or
+          ((retire_status.json.resources[0].retirement_state | lower) == 'retired') or
+          ((retire_status.json.resources[0].retirement_state | lower) == 'error'))
+
+    - fail:
+        msg: 'retirement failed'
+      when:
+        - (retire_status.json.resources | length) > 0
+        - retire_status.json.resources[0].retirement_state is defined
+        - (retire_status.json.resources[0].retirement_state | lower) == 'error'
+
+  always:
+    - name: 'inspect retire_status'
+      debug:
+        var: retire_status
+      when: (debug | bool)

--- a/ansible/test_vm_lifecycle.yml
+++ b/ansible/test_vm_lifecycle.yml
@@ -1,0 +1,43 @@
+- hosts:        'localhost'
+  gather_facts: false
+  connection:   local
+
+  roles:
+    #
+    # pass in the appropriate tag:
+    #   - cloudforms: tests the cloudforms vm provision lifecycle
+    #   - satellite:  tests the satellite vm provision lifecycle
+    #   - tower:      tests the tower vm provision lifecycle
+    #
+
+    #
+    # CLOUDFORMS LIFECYCLE TEST
+    #
+    - role: 'miq_vm_provision'
+      tags:
+        - cloudforms
+    - role: 'miq_vm_retire'
+      vars:
+        miq_vm_id: "{{ request_task_status.json.resources[0].destination_id | default(None) }}"
+      tags:
+        - cloudforms
+
+    #
+    # SATELLITE LIFECYCLE TEST
+    #
+    #- role: 'satellite_vm_provision'
+    #  tags:
+    #    - satellite
+    #- role: 'satellite_vm_retire'
+    #  tags:
+    #    - satellite
+
+    #
+    # TOWER LIFECYCLE TEST
+    #
+    #- role: 'tower_vm_provision'
+    #  tags:
+    #    - tower
+    #- role: 'tower_vm_retire'
+    #  tags:
+    #    - tower


### PR DESCRIPTION
Roles for provision/retire for cloudforms and the playbook to tie the testing of the lifecycle together.